### PR TITLE
Use bit OR 0 instead of Math.floor

### DIFF
--- a/src/util/arrays.js
+++ b/src/util/arrays.js
@@ -36,7 +36,7 @@ export const range = (end, start = 0) => {
 export function shuffle(arr) {
   let tmp, j;
   for (let i = arr.length - 1; i > 0; i--) {
-    j = Math.floor(Math.random() * (i+1));
+    j = (Math.random() * (i+1)) | 0;
     tmp = arr[i];
     arr[i] = arr[j];
     arr[j] = tmp;

--- a/src/util/perms.js
+++ b/src/util/perms.js
@@ -1,6 +1,6 @@
 import { range } from './arrays.js';
 
-const _rand = (max) => (Math.floor(Math.random() * max));
+const _randInt = (max) => ((Math.random() * max) | 0);
 
 const _factorialMap = [1n, 1n];
 const _factorialMapMaxSize = (1<<10);
@@ -344,21 +344,21 @@ export function randomBigInt(upperBound = BigInt(Number.MAX_SAFE_INTEGER)) {
 
   while (bound > 0n) {
     if (bound >= 65536n) {
-      result |= (BigInt(_rand(65536)) << i);
+      result |= (BigInt(_randInt(65536)) << i);
       i += 16n;
       bound >>= 16n;
     } else if (bound >= 256n) {
-      result |= (BigInt(_rand(256)) << i);
+      result |= (BigInt(_randInt(256)) << i);
       i += 8n;
       bound >>= 8n;
     } else if (bound >= 16n) {
-      result |= (BigInt(_rand(16)) << i);
+      result |= (BigInt(_randInt(16)) << i);
       i += 4n;
       bound >>= 4n;
     } else {
       let r = 0;
       do {
-        r = BigInt(_rand(Number(bound)));
+        r = BigInt(_randInt(Number(bound)));
       } while ((result | (BigInt(r) << i)) >= upperBound);
       result |= (r << i);
       bound = 0n;

--- a/test/sudoku/Sudoku.test.js
+++ b/test/sudoku/Sudoku.test.js
@@ -2,10 +2,27 @@ import {
   Sudoku,
   cellCol,
   cellRegion,
+  cellRegion2D,
   cellRow,
-  masksFor
+  masksFor,
+  range
 } from '../../index.js';
 import puzzles from './puzzles24.js';
+
+describe('cellRow, cellCol, cellRegion, cellRegion2D', () => {
+  test('correct values', () => {
+    for (let cellIndex = 80; cellIndex >= 0; cellIndex--) {
+      const row = cellRow(cellIndex);
+      const col = cellCol(cellIndex);
+      const region = cellRegion(cellIndex);
+      const region2D = cellRegion2D(row, col);
+      expect(row).toBe(Math.floor(cellIndex / 9));
+      expect(col).toBe(cellIndex % 9);
+      expect(region).toBe(Math.floor(row / 3) * 3 + Math.floor(col / 3));
+      expect(region2D).toBe(region);
+    }
+  });
+});
 
 describe('Sudoku', () => {
   describe('static', () => {


### PR DESCRIPTION
Related to #26 

Little micro improvements.
`number | 0` seems to be a little faster than `Math.floor(number)`. These things are always going to vary from box to box and version to version. I'm going to side with whichever is the most primitive of operations.

Additionally, I tested pre-generating maps for constant time lookup of `cellRow`, `cellCol`, `cellRegion`, but the performance on my machine was roughly the same as just doing the math, and worse than when using `Object.freeze`.


Some unnecessary double initializations of internal structures in the Sudoku constructor were removed.