### PR TITLE
speedup range creation

### DIFF
--- a/src/util/arrays.js
+++ b/src/util/arrays.js
@@ -21,11 +21,11 @@ function errIfIndicesOutOfBounds(arr, a, b) {
  * @returns {number[]}
  */
 export const range = (end, start = 0) => {
-  if (start === 0) {
-    return [...Array(end).keys()];
-  } else {
-    return [...Array(end - start).keys()].map(v => v + start);
+  const result = [];
+  for (let i = start; i < end; i++) {
+    result.push(i);
   }
+  return result;
 };
 
 /**


### PR DESCRIPTION
Related to #26 

In many (most? all?) cases, vanilla loops are faster iterator methods.

`Apple M2`
`Node v20.14.0`

```js
> function range_old(end, start = 0) {
...   if (start === 0) {
...     return [...Array(end).keys()];
...   } else {
...     return [...Array(end - start).keys()].map(v => v + start);
...   }
... }
undefined
> 
> function range_new(end, start = 0) {
...   const arr = [];
...   for (let i = start; i < end; i++) {
...     arr.push(i);
...   }
...   return arr;
... }
undefined
> 
> [ range_old, range_new].forEach((fn, i) => {
...   for (let n = 1000; n <= 10000000; n*=10) {
...     const tag = `Generating {${n}} ranges (length 81) with ${fn.name}`;
...     console.time(tag);
...     for (let p = 0; p < n; p++) {
...       fn(81);
...     }
...     console.timeEnd(tag);
...   }
... });
Generating {1000} ranges (length 81) with range_old: 2.55ms
Generating {10000} ranges (length 81) with range_old: 16.121ms
Generating {100000} ranges (length 81) with range_old: 153.257ms
Generating {1000000} ranges (length 81) with range_old: 1.441s
Generating {10000000} ranges (length 81) with range_old: 13.427s
Generating {1000} ranges (length 81) with range_new: 0.897ms
Generating {10000} ranges (length 81) with range_new: 2.15ms
Generating {100000} ranges (length 81) with range_new: 20.983ms
Generating {1000000} ranges (length 81) with range_new: 201.612ms
Generating {10000000} ranges (length 81) with range_new: 2.118s
```

(Same results within browser (Chromium/Brave))